### PR TITLE
feat: Add logging everything into gothicvr_log.txt (#40)

### DIFF
--- a/Assets/FileLoggingHandler.cs
+++ b/Assets/FileLoggingHandler.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using UnityEngine;
+
+namespace GVR.Settings
+{
+    public class FileLoggingHandler : MonoBehaviour
+    {
+        private StreamWriter fileWriter;
+
+        private void Awake()
+        {
+            fileWriter = new StreamWriter(Application.persistentDataPath + "/gothicvr_log.txt", false);
+            Application.logMessageReceived += HandleLog;
+            Debug.Log("Init file logging handler done");
+        }
+
+        private void OnDestroy()
+        {
+            Application.logMessageReceived -= HandleLog;
+            fileWriter.Close();
+        }
+
+        private void HandleLog(string logString, string stackTrace, LogType type)
+        {
+            fileWriter.WriteLine(type + ": " + logString);
+            if (type == LogType.Exception)
+            {
+                fileWriter.WriteLine(stackTrace);
+            }
+        }
+    }
+}

--- a/Assets/GothicVR/Scenes/SampleScene.unity
+++ b/Assets/GothicVR/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.17276807, g: 0.21589197, b: 0.29782572, a: 1}
+  m_IndirectSpecularColor: {r: 0.17276844, g: 0.21589246, b: 0.2978263, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2165,6 +2165,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1896514214}
   - component: {fileID: 1896514213}
+  - component: {fileID: 1896514215}
   m_Layer: 0
   m_Name: Settings
   m_TagString: Untagged
@@ -2200,6 +2201,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1896514215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1896514212}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b216c7e049e26b53b9dd2be11080e5e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2135449536
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -133,7 +133,9 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.1
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 1935565065551831612, guid: ea302bef6e5dfab4abc884c353c0926d, type: 2}
+  - {fileID: 3119080696744858793, guid: af3964d8a6279b54a9254cbe6379b9d1, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -724,7 +726,10 @@ PlayerSettings:
   webGLMemoryGeometricGrowthStep: 0.2
   webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    Android: USE_INPUT_SYSTEM_POSE_CONTROL
+    Standalone: USE_INPUT_SYSTEM_POSE_CONTROL
+    Windows Store Apps: USE_INPUT_SYSTEM_POSE_CONTROL
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend:


### PR DESCRIPTION
See #40 .

Currently very simple implementation, should log everything including exceptions into the `gothicvr_log.txt` in the persistent app data path.
I tried adding the log's path to the `GameSettings.json` for customization, but retrieving the `SettingsManager` at such an early time (`Awake()` callback) seems to not be working. Because the logging should start as early as possible to catch as much of the logging as possible I didn't test that way further.
If you think adding the logging path to the settings would be worthwile and know a way to fix the `SettingsManager` retrieval, feel free to push to the branch :).

Also, the script is currently attached to the `Settings` component in the scene; I'm new to Unity, so if this isn't the right place, feel free to move it and give me a heads up about a better way^^.

Oh, and don't get confused by the additional changes in Unity settings; these changes are made automatically when I open the project, probably because the project hasn't been opened in Linux before? If these changes seem wrong, I can remove them.