### PR TITLE
For all meshes we now use a cutout shader by default.

### DIFF
--- a/Assets/GothicVR/Scripts/Creator/MeshCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/MeshCreator.cs
@@ -17,7 +17,7 @@ namespace GVR.Creator
         private static AssetCache assetCache;
 
         // DEBUG - we can change special mesh entries (trees, walls) based on flags later. But for now we can live with the nature cutout shader.
-        private const string DEFAULT_SHADER = "Nature/Tree Creator Leaves Fast";
+        private const string DEFAULT_SHADER = "Nature/Tree Creator Leaves";
 
         void Start()
         {

--- a/Assets/GothicVR/Scripts/Creator/MeshCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/MeshCreator.cs
@@ -16,6 +16,9 @@ namespace GVR.Creator
     {
         private static AssetCache assetCache;
 
+        // DEBUG - we can change special mesh entries (trees, walls) based on flags later. But for now we can live with the nature cutout shader.
+        private const string DEFAULT_SHADER = "Nature/Tree Creator Leaves Fast";
+
         void Start()
         {
             assetCache = SingletonBehaviour<AssetCache>.GetOrCreate();
@@ -162,7 +165,7 @@ namespace GVR.Creator
 
         private void PrepareMeshRenderer(Renderer renderer, WorldData.SubMeshData subMesh)
         {
-            var standardShader = Shader.Find("Standard");
+            var standardShader = Shader.Find(DEFAULT_SHADER);
             var material = new Material(standardShader);
             var bMaterial = subMesh.material;
 
@@ -196,7 +199,7 @@ namespace GVR.Creator
 
             foreach (var subMesh in mrmData.subMeshes)
             {
-                var standardShader = Shader.Find("Standard");
+                var standardShader = Shader.Find(DEFAULT_SHADER);
                 var material = new Material(standardShader);
                 var materialData = subMesh.material;
 


### PR DESCRIPTION
Please check it briefly:
* Wall on old camp
* plants
* and trees are now rendered cutout

![image](https://github.com/GothicVRProject/GothicVR/assets/120568393/cbf6a74d-b2da-479d-ad94-10c0a96dca9b)
