### PR TITLE
Disable zones custom handler if music is deactivated

### DIFF
--- a/Assets/GothicVR/Scripts/Creator/SoundCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/SoundCreator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using GothicVR.Items;
 using GVR.Caches;
+using GVR.Demo;
 using GVR.Phoenix.Interface;
 using GVR.Phoenix.Interface.Vm;
 using GVR.Phoenix.Util;
@@ -69,7 +70,8 @@ namespace GVR.Creator
             soundObject.transform.localScale = (max - min);
             soundObjectCollider.isTrigger = true;
 
-            var musicCollisionHandler = soundObject.AddComponent<MusicCollisionHandler>();
+            if (SingletonBehaviour<DebugSettings>.GetOrCreate().EnableMusic)
+                soundObject.AddComponent<MusicCollisionHandler>();
 
             return soundObject;
         }


### PR DESCRIPTION
Remove the custom collision handler from Music Zones

There are no reasons to add custom collision handling to zones if they are not going to be used when music is disabled
