### PR TITLE
Bugfix/music crash when no musicvm

### DIFF
--- a/Assets/GothicVR/Scripts/Creator/MusicCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/MusicCreator.cs
@@ -38,12 +38,14 @@ namespace GVR.Creator
         private int bufferSize = 2048;
         private short[] shortBuffer;
 
+        private static AudioSource musicSource;
+
         private static GameObject backgroundMusic;
 
         void Start()
         {
-
             backgroundMusic = GameObject.Find("BackgroundMusic");
+            musicSource = backgroundMusic.AddComponent<AudioSource>();
 
             var G1Dir = SingletonBehaviour<SettingsManager>.GetOrCreate().GameSettings.GothicIPath;
 

--- a/Assets/GothicVR/Scripts/Creator/MusicCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/MusicCreator.cs
@@ -207,5 +207,40 @@ namespace GVR.Creator
             pendingTheme = theme;
             hasPending = true;
         }
+
+        private void StopMusic()
+        {
+            if (musicSource.isPlaying)
+                musicSource.Pause();
+
+            // reinitialize music
+            DMMusic.DMusicFreeMusic(music);
+            music = DMMusic.DMusicInitMusic();
+
+            DMMixer.DMusicSetMusic(mixer, music);
+        }
+
+        private void RestartMusic()
+        {
+            hasPending = true;
+            reloadTheme = true;
+        }
+
+        public void setEnabled(bool enable)
+        {
+            var isPlaying = musicSource.isPlaying;
+            if (isPlaying == enable)
+                return;
+
+            if (enable)
+            {
+                RestartMusic();
+                musicSource.Play();
+            }
+            else
+            {
+                StopMusic();
+            }
+        }
     }
 }

--- a/Assets/GothicVR/Scripts/Creator/MusicCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/MusicCreator.cs
@@ -46,6 +46,12 @@ namespace GVR.Creator
         {
             backgroundMusic = GameObject.Find("BackgroundMusic");
             musicSource = backgroundMusic.AddComponent<AudioSource>();
+        }
+
+        public void Create()
+        {
+            if (!SingletonBehaviour<DebugSettings>.GetOrCreate().EnableMusic)
+                return;
 
             var G1Dir = SingletonBehaviour<SettingsManager>.GetOrCreate().GameSettings.GothicIPath;
 
@@ -66,19 +72,12 @@ namespace GVR.Creator
             AddMusicPath(fullPath, "newworld");
             AddMusicPath(fullPath, "AddonWorld");
 
-            // Set initial music
-            setMusic("SYS_Menu");
-
             // Create audio clip with, 4 times the bufferSize so we have enough room, 2 channels and 44100Hz
             var audioClip = AudioClip.Create("Music", bufferSize * 4, 2, 44100, true, PrepareData);
 
-            var source = backgroundMusic.AddComponent<AudioSource>();
-            source.priority = 0;
-            source.clip = audioClip;
-            source.loop = true;
-
-            if (SingletonBehaviour<DebugSettings>.GetOrCreate().EnableMusic)
-                source.Play();
+            musicSource.priority = 0;
+            musicSource.clip = audioClip;
+            musicSource.loop = true;
         }
 
         private void AddMusicPath(string fullPath, string path)

--- a/Assets/GothicVR/Scripts/Importer/PhoenixImporter.cs
+++ b/Assets/GothicVR/Scripts/Importer/PhoenixImporter.cs
@@ -50,7 +50,7 @@ namespace GVR.Importer
             LoadMusic();
 
             PxVm.CallFunction(PhoenixBridge.VmGothicPtr, "STARTUP_SUB_OLDCAMP"); // Goal: Spawn Bloodwyn ;-)        
-           //LoadFonts();
+                                                                                 //LoadFonts();
 
             watch.Stop();
             Debug.Log($"Time spent for loading world + VM + npc loading: {watch.Elapsed}");
@@ -65,7 +65,7 @@ namespace GVR.Importer
         [MonoPInvokeCallback(typeof(PxLogging.PxLogCallback))]
         public static void PxLoggerCallback(PxLogging.Level level, string message)
         {
-            switch(level)
+            switch (level)
             {
                 case PxLogging.Level.warn:
                     Debug.LogWarning(message);
@@ -109,7 +109,7 @@ namespace GVR.Importer
 
             PhoenixBridge.VmGothicPtr = vmPtr;
         }
-        
+
         private void LoadSfxVM(string G1Dir)
         {
             var fullPath = Path.GetFullPath(Path.Join(G1Dir, "/_work/DATA/scripts/_compiled/SFX.DAT"));
@@ -126,6 +126,8 @@ namespace GVR.Importer
 
         private void LoadMusic()
         {
+            if (!SingletonBehaviour<DebugSettings>.GetOrCreate().EnableMusic)
+                return;
             var music = SingletonBehaviour<MusicCreator>.GetOrCreate();
             music.Create();
             music.setEnabled(true);
@@ -187,13 +189,13 @@ namespace GVR.Importer
                 PxVm.pxVmDestroy(PhoenixBridge.VmGothicPtr);
                 PhoenixBridge.VmGothicPtr = IntPtr.Zero;
             }
-            
+
             if (PhoenixBridge.VmSfxPtr != IntPtr.Zero)
             {
                 PxVm.pxVmDestroy(PhoenixBridge.VmSfxPtr);
                 PhoenixBridge.VmSfxPtr = IntPtr.Zero;
             }
-            if(PhoenixBridge.VmMusicPtr != IntPtr.Zero)
+            if (PhoenixBridge.VmMusicPtr != IntPtr.Zero)
             {
                 PxVm.pxVmDestroy(PhoenixBridge.VmMusicPtr);
                 PhoenixBridge.VmMusicPtr = IntPtr.Zero;

--- a/Assets/GothicVR/Scripts/Importer/PhoenixImporter.cs
+++ b/Assets/GothicVR/Scripts/Importer/PhoenixImporter.cs
@@ -47,6 +47,7 @@ namespace GVR.Importer
             LoadSfxVM(G1Dir);
             LoadMusicVM(G1Dir);
             LoadWorld(vdfPtr);
+            LoadMusic();
 
             PxVm.CallFunction(PhoenixBridge.VmGothicPtr, "STARTUP_SUB_OLDCAMP"); // Goal: Spawn Bloodwyn ;-)        
            //LoadFonts();
@@ -121,6 +122,15 @@ namespace GVR.Importer
             var fullPath = Path.GetFullPath(Path.Join(G1Dir, "/_work/DATA/scripts/_compiled/MUSIC.DAT"));
             var vmPtr = VmGothicBridge.LoadVm(fullPath);
             PhoenixBridge.VmMusicPtr = vmPtr;
+        }
+
+        private void LoadMusic()
+        {
+            var music = SingletonBehaviour<MusicCreator>.GetOrCreate();
+            music.Create();
+            music.setEnabled(true);
+            music.setMusic("SYS_LOADING");
+            Debug.Log("Loading music");
         }
 
         /// <summary>


### PR DESCRIPTION
When creating the music component we might reference to a nullpointer of MusicVM and crash Unity so we're moving the initialization from Start to Create
Also initialize music back in PhoenixImporter.cs