### PR TITLE
Bugfix/sound and decal performance regression

### DIFF
--- a/Assets/GothicVR/Scenes/Bootstrap.unity
+++ b/Assets/GothicVR/Scenes/Bootstrap.unity
@@ -325,7 +325,7 @@ MonoBehaviour:
   EnableNpcRoutines: 1
   CreateExampleAnimation: 0
   ShowVdfsFileNotFoundErrors: 0
-  EnableSounds: 1
+  EnableSounds: 0
   EnableMusic: 0
 --- !u!1 &705507993
 GameObject:

--- a/Assets/GothicVR/Scenes/Bootstrap.unity
+++ b/Assets/GothicVR/Scenes/Bootstrap.unity
@@ -320,6 +320,7 @@ MonoBehaviour:
   StartMinute: 59
   EnableVobFPMesh: 0
   EnableVobFPMeshEditorLabel: 0
+  EnableDecals: 0
   EnableNpc: 1
   EnableNpcRoutines: 1
   CreateExampleAnimation: 0

--- a/Assets/GothicVR/Scripts/Creator/VobCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/VobCreator.cs
@@ -273,6 +273,10 @@ namespace GVR.Creator
 
         private void CreateDecal(PxVobData vob)
         {
+            if(!FeatureFlags.Instance.EnableDecals)
+            {
+                return;
+            }
             var parent = parentGos[vob.type];
             
             meshCreator.CreateDecal(vob, parent);

--- a/Assets/GothicVR/Scripts/Debugging/FeatureFlags.cs
+++ b/Assets/GothicVR/Scripts/Debugging/FeatureFlags.cs
@@ -29,6 +29,7 @@ namespace GVR.Debugging
         public bool EnableVobFPMesh;
         [Tooltip("For Debug purposes within Scene view in Editor only. Might imply some performance issues in Editor mode.")]
         public bool EnableVobFPMeshEditorLabel;
+        public bool EnableDecals;
         
         [Header("__________NPCs__________")]
         public bool EnableNpc;


### PR DESCRIPTION
Disable decals and sound VOb, as they seem to be the biggest performance hit for the game
e.g. in editor at "FP_PICKRICE_SWAMP_02" spot with them enabled i get 30 fps and with them disabled i get 60 fps

video attached as proof

https://github.com/GothicVRProject/GothicVR/assets/23665744/346d9cfd-a8d0-49b7-a19f-d65f98ff6955


* [x] Tested with PCVR and one mobile VR device (Pico/Quest)

