### PR TITLE
Use vulkan instead of opengl for android builds

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,8 +134,7 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.1
-  preloadedAssets:
-  - {fileID: -5702201265392082154, guid: ea302bef6e5dfab4abc884c353c0926d, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -156,6 +155,7 @@ PlayerSettings:
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
     Android: com.GothicVRProject.GothicVR
+    Standalone: com.GothicVRProject.GothicVR
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -416,7 +416,7 @@ PlayerSettings:
     m_GraphicsJobMode: 0
   m_BuildTargetGraphicsAPIs:
   - m_BuildTarget: AndroidPlayer
-    m_APIs: 0b000000
+    m_APIs: 150000000b000000
     m_Automatic: 0
   - m_BuildTarget: iOSSupport
     m_APIs: 10000000


### PR DESCRIPTION
Vulkan goes brr in a good way compared to opengl (it shouldn't crash)

Using OpenGL, when going from a world (e.g. oldmine) back to world.zen, after loading the world, unity throws a signal 11 (SIGSEGV), code 2 (SEGV_MAPERR).

Using Vulkan it seems to not crash in this situation

* [x] Tested with mobile VR device (Quest)
* [x] Tested with mobile VR device (Pico)

