### PR TITLE
Vdf loading fixed - patched vdf-files are now prioritized.

### DIFF
--- a/Assets/GothicVR/Dependencies/PxCs.dll
+++ b/Assets/GothicVR/Dependencies/PxCs.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:abcfcc2f582cf246d39bb7c78d6cbbe63550f334c33e840eeae62ec047d1c07b
+oid sha256:d1c520b57f0e2182e690f2931cf716b3e85b454c99ee50c4c8211fd04b939959
 size 76800

--- a/Assets/GothicVR/Dependencies/libphoenix-shared.dll
+++ b/Assets/GothicVR/Dependencies/libphoenix-shared.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:090aedfec914d87ba91dd3a36e1471e9c018979439cd879827d1ee7aca883a96
+oid sha256:beb1bb55d8428f3458a8cec192a0b1cef23f8feeb89f5b34b1e7bf3b9ceea18c
 size 4587017

--- a/Assets/GothicVR/Dependencies/libphoenix-shared.so
+++ b/Assets/GothicVR/Dependencies/libphoenix-shared.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8513e07c20b726b716d4b8732fd82e1caaa0a00946d3d125c203632b6386eaca
+oid sha256:4341dec813ac7c009f3bc06fe3143a3cd89b53073cb74e948525e96b5851ee02
 size 7672104

--- a/Assets/GothicVR/Scripts/Phoenix/Interface/VfsBridge.cs
+++ b/Assets/GothicVR/Scripts/Phoenix/Interface/VfsBridge.cs
@@ -9,8 +9,7 @@ namespace GVR.Phoenix.Interface
         public static IntPtr LoadVfsInDirectory(string vfsDir)
         {
             var vfsPaths = Directory.GetFiles(vfsDir, "*.VDF");
-            return PxVfs.LoadVfs(vfsPaths);
+            return PxVfs.LoadVfs(vfsPaths, PxVfs.PxVfsOverwriteBehavior.PxVfsOverwrite_Older);
         }
     }
-
 }


### PR DESCRIPTION
Hint: Can be merged after https://github.com/GothicKit/phoenix-csharp-interface/pull/28 earliest.

# To test
1. Start game and go to gomez room. If the picture next to the table is hero with Harpye, then it's right (if it'S a woman with lizards, it's wrong)
2. (bonus, non blocking) Also check if the loading of russina game version has different loading screen. (Should be fixed as well)

![image](https://github.com/GothicVRProject/GothicVR/assets/120568393/ac5272ae-6d8a-4bbf-9992-6d90f4530cf3)


# Checklist

# Testing
* [x] Merged _main_ into this branch and tested with the latest features
* [x] Tested with PCVR
* [x] Tested with Pico / Quest

## Dependencies
* [x] If libphoenix-shared.dll is changed, .so is also changed
