### PR TITLE
add menu skip flag

### DIFF
--- a/Assets/GothicVR/Scenes/Bootstrap.unity
+++ b/Assets/GothicVR/Scenes/Bootstrap.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.17276844, g: 0.21589246, b: 0.2978263, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -331,6 +331,7 @@ MonoBehaviour:
   CreateVobs: 1
   CreateWaypoints: 0
   CreateWaypointEdges: 0
+  SkipMainMenu: 1
   EnableDayTime: 1
   SunMovementPerformanceValue: 0
   StartHour: 17
@@ -1032,6 +1033,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d06cd27c7d627aa499a0430dd39b8238, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  MainMenuImageBackgroundMaterial: {fileID: 0}
+  MainMenuBackgroundMaterial: {fileID: 0}
+  MainMenuTextImageMaterial: {fileID: 0}
   backgroundmaterial: {fileID: 2100000, guid: 1e349bd46543d684da0fd00dfcc78b72, type: 2}
   buttonmaterial: {fileID: 2100000, guid: 731db01b086aeb94582b82a16a95775b, type: 2}
   slidermaterial: {fileID: 2100000, guid: 9edb2534304dae240937e63c8a079e58, type: 2}
@@ -1060,10 +1064,13 @@ MonoBehaviour:
     m_Bits: 0
   MenuFontTag: Title
   SubtitleFontTag: IngameText
+  ClimbableTag: Climbable
   MeshPerFrame: 10
   VObPerFrame: 75
   moveSpeedPlayerPref: MoveSpeed
   turnSettingPlayerPref: TurnSetting
+  selectedWorld: world.zen
+  selectedWaypoint: START
 --- !u!114 &1896514221
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/GothicVR/Scripts/Debugging/FeatureFlags.cs
+++ b/Assets/GothicVR/Scripts/Debugging/FeatureFlags.cs
@@ -17,6 +17,7 @@ namespace GVR.Debugging
         public bool CreateVobs;
         public bool CreateWaypoints;
         public bool CreateWaypointEdges;
+        public bool SkipMainMenu;
 
         [Header("__________DayTime__________")]
         public bool EnableDayTime;

--- a/Assets/GothicVR/Scripts/Manager/GvrSceneManager.cs
+++ b/Assets/GothicVR/Scripts/Manager/GvrSceneManager.cs
@@ -45,7 +45,10 @@ namespace GVR.Manager
         /// </summary>
         public async Task LoadStartupScenes()
         {
-            await LoadMainMenu();
+            if (FeatureFlags.I.SkipMainMenu)
+                await LoadWorld(ConstantsManager.I.selectedWorld, ConstantsManager.I.selectedWaypoint);
+            else
+                await LoadMainMenu();
         }
 
         private async Task LoadMainMenu()


### PR DESCRIPTION
Add flag to skip main menu and load directly into the world
To modify the starting world and position modify selectedWorld and selectedWaypoint in ConstantsManager
# To test
1. Check menu skip flag and load world
