### PR TITLE
bugfix/reset the list with the nonTeleport GameObjects

### DIFF
--- a/Assets/GothicVR/Scripts/Creator/VobCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/VobCreator.cs
@@ -72,6 +72,7 @@ namespace GVR.Creator
             vobRootNonTeleport.SetParent(rootNonTeleport);
             
             parentGosTeleport = new();
+            parentGosNonTeleport = new();
 
             CreateParentVobObjectTeleport(vobRootTeleport);
             CreateParentVobObjectNonTeleport(vobRootNonTeleport);


### PR DESCRIPTION
# To test
1. Go to another world (e.g. old mine, free mine)



# Testing
* [x] Tested with PCVR
* [x] Tested with Pico / Quest
