### PR TITLE
Alpha to coverage shader for alpha clipped objects

### DIFF
--- a/Assets/GothicVR/Scripts/Caches/AssetCache.cs
+++ b/Assets/GothicVR/Scripts/Caches/AssetCache.cs
@@ -69,14 +69,26 @@ namespace GVR.Caches
             }
 
             var format = pxTexture.format.AsUnityTextureFormat();
-            var texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, (int)pxTexture.mipmapCount, false);
+
+            Texture2D texture = null;
+            if (pxTexture.format == PxTexture.Format.tex_B8G8R8A8)
+            {
+                texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, true);
+                texture.SetPixelData(pxTexture.mipmaps[0].mipmap, 0);
+                texture.Apply(true, true);
+            }
+            else
+            {
+                texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, (int)pxTexture.mipmapCount, false);
+                for (int i = 0; i < pxTexture.mipmapCount; i++)
+                {
+                    texture.SetPixelData(pxTexture.mipmaps[i].mipmap, i);
+                }
+                texture.Apply(false, true);
+            }
+
+            texture.filterMode = FilterMode.Trilinear;
             texture.name = key;
-
-            for (var i = 0u; i < pxTexture.mipmapCount; i++)
-                texture.SetPixelData(pxTexture.mipmaps[i].mipmap, (int)i);
-
-            texture.Apply();
-
             textureCache[preparedKey] = texture;
             return texture;
         }
@@ -92,7 +104,7 @@ namespace GVR.Caches
 
             return newData;
         }
-        
+
         public PxAnimationData TryGetAnimation(string mdsKey, string animKey)
         {
             var preparedMdsKey = GetPreparedKey(mdsKey);
@@ -141,10 +153,10 @@ namespace GVR.Caches
             mdmCache[preparedKey] = newData;
 
             FixArmorTriangles(preparedKey, newData);
-            
+
             return newData;
         }
-        
+
         /// <summary>
         /// Some armor mdm's have wrong triangles. This function corrects them hard coded until we find a proper solution.
         /// </summary>
@@ -152,7 +164,7 @@ namespace GVR.Caches
         {
             if (!misplacedMdmArmors.Contains(key, StringComparer.OrdinalIgnoreCase))
                 return;
-            
+
             foreach (var mesh in mdm.meshes!)
             {
                 for (var i = 0; i < mesh.mesh!.positions!.Length; i++)
@@ -198,7 +210,7 @@ namespace GVR.Caches
 
             return newData;
         }
-        
+
         /// <summary>
         /// Hint: Instances only need to be initialized once on phoenix.
         /// There are two ways of getting Item data. Via INSTANCE name or symbolIndex inside VM.

--- a/Assets/GothicVR/Scripts/Caches/AssetCache.cs
+++ b/Assets/GothicVR/Scripts/Caches/AssetCache.cs
@@ -73,12 +73,14 @@ namespace GVR.Caches
             Texture2D texture = null;
             if (pxTexture.format == PxTexture.Format.tex_B8G8R8A8)
             {
+                // Let Unity generate mips for textures with alpha, as the game doesn't provide them.
                 texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, true);
                 texture.SetPixelData(pxTexture.mipmaps[0].mipmap, 0);
                 texture.Apply(true, true);
             }
             else
             {
+                // Use Gothic's mips for opaque textures. We could also let Unity generate them here, though.
                 texture = new Texture2D((int)pxTexture.width, (int)pxTexture.height, format, (int)pxTexture.mipmapCount, false);
                 for (int i = 0; i < pxTexture.mipmapCount; i++)
                 {

--- a/Assets/GothicVR/Scripts/Creator/Meshes/AbstractMeshCreator.cs
+++ b/Assets/GothicVR/Scripts/Creator/Meshes/AbstractMeshCreator.cs
@@ -18,6 +18,7 @@ namespace GVR.Creator.Meshes
         // until we know how to change specifics to the cutout only. (e.g. bushes)
         protected const string defaultShader = "Universal Render Pipeline/Unlit"; // "Unlit/Transparent Cutout";
         private const string waterShader = "Shader Graphs/Unlit_Both_ScrollY"; //Vinces moving texture water shader
+        private const string alphaToCoverageShaderName = "Unlit/Unlit-AlphaToCoverage";
         protected const float decalOpacity = 0.75f;
 
 
@@ -504,12 +505,13 @@ namespace GVR.Creator.Meshes
             var shader = Shader.Find(defaultShader);
             if (isAlphaTest)
             {
-                shader = Shader.Find("Unlit/Unlit-AlphaToCoverage");
+                shader = Shader.Find(alphaToCoverageShaderName);
             }
             var material = new Material(shader);
             if (isAlphaTest)
             {
-                material.renderQueue = 2450;
+                // Manually correct the render queue for alpha test, as Unity doesn't want to do it from the shader's render queue tag.
+                material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.AlphaTest;
             }
             return material;
         }

--- a/Assets/GothicVR/Settings/URP-Balanced.asset
+++ b/Assets/GothicVR/Settings/URP-Balanced.asset
@@ -23,9 +23,9 @@ MonoBehaviour:
   m_RequireOpaqueTexture: 0
   m_OpaqueDownsampling: 1
   m_SupportsTerrainHoles: 1
-  m_SupportsHDR: 1
+  m_SupportsHDR: 0
   m_HDRColorBufferPrecision: 0
-  m_MSAA: 1
+  m_MSAA: 4
   m_RenderScale: 1
   m_UpscalingFilter: 0
   m_FsrOverrideSharpness: 0
@@ -34,7 +34,7 @@ MonoBehaviour:
   m_LODCrossFadeDitheringType: 1
   m_ShEvalMode: 0
   m_MainLightRenderingMode: 1
-  m_MainLightShadowsSupported: 1
+  m_MainLightShadowsSupported: 0
   m_MainLightShadowmapResolution: 1024
   m_AdditionalLightsRenderingMode: 1
   m_AdditionalLightsPerObjectLimit: 2

--- a/Assets/GothicVR/Settings/URP-Performant.asset
+++ b/Assets/GothicVR/Settings/URP-Performant.asset
@@ -22,10 +22,10 @@ MonoBehaviour:
   m_RequireDepthTexture: 0
   m_RequireOpaqueTexture: 0
   m_OpaqueDownsampling: 1
-  m_SupportsTerrainHoles: 1
+  m_SupportsTerrainHoles: 0
   m_SupportsHDR: 0
   m_HDRColorBufferPrecision: 0
-  m_MSAA: 2
+  m_MSAA: 4
   m_RenderScale: 1
   m_UpscalingFilter: 0
   m_FsrOverrideSharpness: 0

--- a/Assets/GothicVR/Shaders/Unlit-AlphaToCoverage.shader
+++ b/Assets/GothicVR/Shaders/Unlit-AlphaToCoverage.shader
@@ -74,10 +74,10 @@ Shader "Unlit/Unlit-AlphaToCoverage"
             half4 frag (v2f i) : SV_Target
             {
                 half4 col = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv);
-                // rescale alpha by mip level (if not using preserved coverage mip maps)
+                // Rescale alpha by mip level since preserved coverage mip maps can't be generated at runtime.
                 col.a *= 1 + max(0, CalcMipLevel(i.uv * _MainTex_TexelSize.zw)) * _MipScale;
                 // Rescale alpha by partial derivative, faded by distance. This way, at a distance, the wide coverage is kept to reduce aliasing further.
-                col.a = lerp((col.a - _Cutoff) / max(fwidth(col.a), 0.0001) + 0.5, col.a, saturate(i.distance / _DistanceFade));
+                col.a = lerp((col.a - _Cutoff) / max(fwidth(col.a), 0.0001) + 0.5, col.a, saturate(max(i.distance, 0.0001) / _DistanceFade));
                 return col;
             }
             ENDHLSL

--- a/Assets/GothicVR/Shaders/Unlit-AlphaToCoverage.shader
+++ b/Assets/GothicVR/Shaders/Unlit-AlphaToCoverage.shader
@@ -1,0 +1,86 @@
+Shader "Unlit/Unlit-AlphaToCoverage"
+{
+    Properties
+    {
+        _MainTex("Texture", 2D) = "white" {}
+        _Cutoff ("Cutoff", Range(0,1)) = 0.7
+        _MipScale ("Mip scale", Range(0,1)) = 0.25
+        _DistanceFade("Distance to wide coverage", Float) = 10
+    }
+    SubShader
+    {
+        Tags {  "RenderType" = "TransparentCutout" "RenderPipeline" = "UniversalPipeline" "RenderQueue" = "AlphaTest" }
+         AlphaToMask On
+
+        Pass
+        {
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+                float distance : TEXCOORD1;
+
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            CBUFFER_START(UnityPerMaterial)
+                TEXTURE2D(_MainTex);
+                SAMPLER(sampler_MainTex);
+                float4 _MainTex_ST;
+                float4 _MainTex_TexelSize;
+                half _Cutoff;
+                half _MipScale;
+                float _DistanceFade;
+            CBUFFER_END
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                float3 toCamera = TransformObjectToWorld(v.vertex) - _WorldSpaceCameraPos;
+                o.distance = length(toCamera);
+                o.vertex = TransformObjectToHClip(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                return o;
+            }
+
+            // https://bgolus.medium.com/anti-aliased-alpha-test-the-esoteric-alpha-to-coverage-8b177335ae4f
+            float CalcMipLevel(float2 texture_coord)
+            {
+                float2 dx = ddx(texture_coord);
+                float2 dy = ddy(texture_coord);
+                float delta_max_sqr = max(dot(dx, dx), dot(dy, dy));
+
+                return max(0.0, 0.5 * log2(delta_max_sqr));
+            }
+
+            half4 frag (v2f i) : SV_Target
+            {
+                half4 col = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, i.uv);
+                // rescale alpha by mip level (if not using preserved coverage mip maps)
+                col.a *= 1 + max(0, CalcMipLevel(i.uv * _MainTex_TexelSize.zw)) * _MipScale;
+                // Rescale alpha by partial derivative, faded by distance. This way, at a distance, the wide coverage is kept to reduce aliasing further.
+                col.a = lerp((col.a - _Cutoff) / max(fwidth(col.a), 0.0001) + 0.5, col.a, saturate(i.distance / _DistanceFade));
+                return col;
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/GothicVR/Shaders/Unlit-AlphaToCoverage.shader.meta
+++ b/Assets/GothicVR/Shaders/Unlit-AlphaToCoverage.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6177a3f8311d19a48b15a5fda3907388
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -30,10 +30,11 @@ GraphicsSettings:
   - {fileID: 4800000, guid: 650dd9526735d5b46b79224bc6e94025, type: 3}
   - {fileID: -6465566751694194690, guid: 9b4e681081e2b4c469111bb649e2f7ee, type: 3}
   - {fileID: -6465566751694194690, guid: 6a56f4d49ccc01c4caeafc424f9766ed, type: 3}
+  - {fileID: 4800000, guid: 6177a3f8311d19a48b15a5fda3907388, type: 3}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_CustomRenderPipeline: {fileID: 11400000, guid: 089847605d084b343862e74b26dbeca9, type: 2}
+  m_CustomRenderPipeline: {fileID: 11400000, guid: ff1e1f739462f6446bfdd47f8653ddb3, type: 2}
   m_TransparencySortMode: 0
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}
   m_DefaultRenderingPath: 1

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -21,8 +21,8 @@ QualitySettings:
     skinWeights: 2
     globalTextureMipmapLimit: 0
     textureMipmapLimitSettings: []
-    anisotropicTextures: 0
-    antiAliasing: 2
+    anisotropicTextures: 1
+    antiAliasing: 4
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0


### PR DESCRIPTION
Greatly reduce aliasing on alpha clipped textures. Separate shaders for opaque and alpha clipped materials. Manually generate mips for textures with transparency.