### PR TITLE
Sounds fixed - Right ones will be enabled next to player when spawned.

### DIFF
--- a/Assets/GothicVR/Scenes/Bootstrap.unity
+++ b/Assets/GothicVR/Scenes/Bootstrap.unity
@@ -854,6 +854,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cbf7a98cf00d737498f767805a1f7b75, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  vobSoundsAndDayTime: []
 --- !u!4 &1613829617
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/GothicVR/Scripts/Caches/LookupCache.cs
+++ b/Assets/GothicVR/Scripts/Caches/LookupCache.cs
@@ -1,16 +1,11 @@
-using GVR.Phoenix.Interface;
-using GVR.Phoenix.Util;
-using GVR.Util;
-using PxCs.Data.Mesh;
-using PxCs.Data.Model;
-using PxCs.Interface;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using GVR.Npc;
+using GVR.Manager;
 using GVR.Properties;
+using GVR.Util;
 using TMPro;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace GVR.Caches
 {
@@ -37,5 +32,20 @@ namespace GVR.Caches
         /// </summary>
         public Dictionary<string, TMP_SpriteAsset> fontCache = new();
 
+        /// <summary>
+        /// VobSounds and VobSoundsDayTime GOs.
+        /// </summary>
+        public List<GameObject> vobSoundsAndDayTime = new();
+        
+        
+        private void Start()
+        {
+            GvrSceneManager.I.sceneGeneralUnloaded.AddListener(PreWorldCreate);
+        }
+
+        private void PreWorldCreate()
+        {
+            vobSoundsAndDayTime.Clear();
+        }
     }
 }


### PR DESCRIPTION
# To test
1. Load game with Sounds and SoundCulling activated (default within FeatureFlags already)
2. Check if you don't hear false sounds from somewhere across the world (e.g. alchemy lab sounds)
3. Check if you hear sounds when you stand at your spawnpoint for a couple of seconds (Startpoint: Water)

Before that fix, you heard fully wrong sounds from somewhere across the world OR heard no sound at all when spawned.

# Checklist
## Scene
* [x] FeatureFlags reverted to right value
# Testing
* [x] Merged _main_ into this branch and tested with the latest features
* [x] Tested with PCVR
