### PR TITLE
Changed the open menu command from primary left to secondary left but…

### DIFF
--- a/Assets/GothicVR/Scripts/Player/BasicMovement/ControllerManager.cs
+++ b/Assets/GothicVR/Scripts/Player/BasicMovement/ControllerManager.cs
@@ -31,7 +31,7 @@ public class ControllerManager : MonoBehaviour
         rightSecondaryButtonAction = new InputAction("secondaryButton", binding: "<XRController>{RightHand}/secondaryButton");
 
 
-        rightPrimaryButtonAction.started += ctx => ShowMainMenu();
+        rightSecondaryButtonAction.started += ctx => ShowMainMenu();
 
         rightPrimaryButtonAction.Enable();
         rightSecondaryButtonAction.Enable();


### PR DESCRIPTION
…ton to avoid weird teleporation behaviour

# To test
- [ ] Press primary right button -> main menu should not open
- [ ] Press secondary right button -> main menu should open
- [ ] Teleport to multiple locations with opening and closing the menu in between
- [ ] No weird behaviour should appear


# Checklist
(Please judge for yourself which entry is valuable for your PR)

## Scene
* [ ] FeatureFlags reverted to right value

# Testing
* [ ] Merged _main_ into this branch and tested with the latest features
* [ ] Tested with PCVR
* [ ] Tested with Pico / Quest

## Dependencies
* [ ] If libphoenix-shared.dll is changed, .so is also changed
