### PR TITLE
bug fix - no physics on released items

### DIFF
--- a/Assets/GothicVR/Scripts/Manager/Culling/VobMeshCullingManager.cs
+++ b/Assets/GothicVR/Scripts/Manager/Culling/VobMeshCullingManager.cs
@@ -307,7 +307,7 @@ namespace GVR.Manager.Culling
 
         public void StopTrackVobPositionUpdates(GameObject go)
         {
-            if (pausedVobsToReenable.ContainsKey(go))
+            if (pausedVobsToReenableCoroutine.ContainsKey(go))
                 return;
 
             pausedVobsToReenableCoroutine.Add(go, StartCoroutine(StopTrackVobPositionUpdatesDelayed(go)));
@@ -340,8 +340,8 @@ namespace GVR.Manager.Culling
         {
             yield return new WaitForSeconds(1f);
             pausedVobsToReenableCoroutine.Remove(go);
-
-            pausedVobsToReenable.Add(go, go.GetComponent<Rigidbody>());
+            if(!pausedVobsToReenable.ContainsKey(go))
+                pausedVobsToReenable.Add(go, go.GetComponent<Rigidbody>());
         }
 
         private IEnumerator StopVobTrackingBasedOnVelocity()

--- a/Assets/GothicVR/Scripts/Vob/ItemGrabInteractable.cs
+++ b/Assets/GothicVR/Scripts/Vob/ItemGrabInteractable.cs
@@ -9,26 +9,27 @@ namespace GVR.Vob
     {
         public GameObject attachPoint1;
         public GameObject attachPoint2;
-        
-        private bool alreadyGrabbedOnce;
-        
+
+        public Rigidbody rb;
+
+        private void Start()
+        {
+            rb = GetComponent<Rigidbody>();
+        }
+
         public void SelectEntered(SelectEnterEventArgs args)
         {
             VobMeshCullingManager.I.StartTrackVobPositionUpdates(gameObject);
         }
-        
+
         /// <summary>
-        /// Activate physics on object immediately after it's stopped being grabbed for the first time.
+        /// Activate physics on object immediately after it's stopped being grabbed
         /// </summary>
         public void SelectExited(SelectExitEventArgs args)
         {
+            if (rb.isKinematic)
+                rb.isKinematic = false;
             VobMeshCullingManager.I.StopTrackVobPositionUpdates(gameObject);
-            
-            if (alreadyGrabbedOnce)
-                return;
-
-            GetComponent<Rigidbody>().isKinematic = false;
-            alreadyGrabbedOnce = true;
         }
     }
 }


### PR DESCRIPTION
this is a fix to bug reported on discord here -> https://discord.com/channels/1000261958668406874/1221494186935586866

removed alreadyGrabbedOnce bool and checking if rigidbody isKinematic instead. only setting the physics on if they are off right now. assigning rigidbody on start instead of using getComponent on item release
moved VobMeshCullingManager.I.StopTrackVobPositionUpdates(gameObject); to the bottom of the release method sometimes there would be an error with vob mesh culling and that would stop physics from being re-enabled on item release

fixed checks in VobMeshCullingManager to make sure it never adds the same game object to the dictionary