### PR TITLE
Update Zenkit to latest version

### DIFF
--- a/Assets/GothicVR/Dependencies/ZenKit.dll
+++ b/Assets/GothicVR/Dependencies/ZenKit.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55da5f31955fcdb8f0193742b8284839e210f530722b6f3f6d2dada5fc84c53a
+oid sha256:bca9a700f3edc94a1347a9cb9b359e4e7692b71fff0f65081f7f43f43923e450
 size 501760

--- a/Assets/GothicVR/Dependencies/libzenkitcapi.so
+++ b/Assets/GothicVR/Dependencies/libzenkitcapi.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38adb2d0a72c8b088ae2263e695eb44ad9ab7f10bf7ce387f7b1708b45874fdc
-size 8994336
+oid sha256:86eb9765463246aff9bacf114aea654517bac23889aed8383d0f377ca9989973
+size 9002736

--- a/Assets/GothicVR/Dependencies/zenkitcapi.dll
+++ b/Assets/GothicVR/Dependencies/zenkitcapi.dll
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f39c67078e57ca4326dc2df4fcd694bf171ee42e2956f4531021443815666360
-size 6001912
+oid sha256:0eff79dd7f8eda3826fc328519a8b1033c9f749a195e31eb51e4e1df9038eecf
+size 6005295


### PR DESCRIPTION
Fixes color issues for r5b6g5 textures --> look at the sky. Is it ok again?