### PR TITLE
fix(GothicSky.mat): Changes during Editor.OnValidate() removed as the…

### DIFF
--- a/Assets/GothicVR/Scenes/Worlds/world.zen.unity
+++ b/Assets/GothicVR/Scenes/Worlds/world.zen.unity
@@ -26,7 +26,7 @@ RenderSettings:
   m_AmbientIntensity: 1
   m_AmbientMode: 3
   m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
-  m_SkyboxMaterial: {fileID: 2100000, guid: 39ac659c922b5b1489714aacd9b952e9, type: 2}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
   m_FlareFadeSpeed: 3

--- a/Assets/GothicVR/Scripts/Manager/SkyManager.cs
+++ b/Assets/GothicVR/Scripts/Manager/SkyManager.cs
@@ -66,11 +66,6 @@ namespace GVR.GothicVR.Scripts.Manager
             GvrEvents.GeneralSceneLoaded.AddListener(InitRainGO);
         }
 
-        private void OnValidate()
-        {
-            SetShaderProperties();
-        }
-
         public void InitSky()
         {
             stateList.AddRange(new[]
@@ -173,7 +168,6 @@ namespace GVR.GothicVR.Scripts.Manager
 
             if (lerpFraction >= 1 && noSky == false)
             {
-                noSky = false;
                 return; // finished blending
             }
 

--- a/Assets/GothicVR/Scripts/Manager/SkyManager.cs
+++ b/Assets/GothicVR/Scripts/Manager/SkyManager.cs
@@ -19,8 +19,11 @@ namespace GVR.GothicVR.Scripts.Manager
     public class SkyManager : SingletonBehaviour<SkyManager>
     {
         public Transform SunDirection;
+        [Tooltip("Changes will be reflected in Editor Runtime mode for testing purposes.")]
         public Color SunColor;
+        [Tooltip("Changes will be reflected in Editor Runtime mode for testing purposes.")]
         public Color AmbientColor;
+        [Tooltip("Changes will be reflected in Editor Runtime mode for testing purposes.")]
         [Range(0, 1)]
         public float PointLightIntensity = 1f;
         public bool IsRaining;
@@ -64,6 +67,11 @@ namespace GVR.GothicVR.Scripts.Manager
             GvrEvents.GameTimeSecondChangeCallback.AddListener(Interpolate);
             GvrEvents.GameTimeHourChangeCallback.AddListener(UpdateRainTime);
             GvrEvents.GeneralSceneLoaded.AddListener(GeneralSceneLoaded);
+        }
+
+        private void OnValidate()
+        {
+            SetShaderProperties();
         }
 
         public void InitSky()

--- a/Assets/GothicVR/Scripts/Manager/SkyManager.cs
+++ b/Assets/GothicVR/Scripts/Manager/SkyManager.cs
@@ -63,7 +63,7 @@ namespace GVR.GothicVR.Scripts.Manager
         {
             GvrEvents.GameTimeSecondChangeCallback.AddListener(Interpolate);
             GvrEvents.GameTimeHourChangeCallback.AddListener(UpdateRainTime);
-            GvrEvents.GeneralSceneLoaded.AddListener(InitRainGO);
+            GvrEvents.GeneralSceneLoaded.AddListener(GeneralSceneLoaded);
         }
 
         public void InitSky()
@@ -247,6 +247,13 @@ namespace GVR.GothicVR.Scripts.Manager
             Shader.SetGlobalColor(SunColorShaderId, SunColor);
             Shader.SetGlobalColor(AmbientShaderId, AmbientColor);
             Shader.SetGlobalFloat(PointLightIntensityShaderId, PointLightIntensity);
+        }
+
+        private void GeneralSceneLoaded()
+        {
+            RenderSettings.skybox = Instantiate(TextureManager.I.skyMaterial);
+
+            InitRainGO();
         }
 
         private void InitRainGO()

--- a/Assets/GothicVR/Scripts/UI/TextureManager.cs
+++ b/Assets/GothicVR/Scripts/UI/TextureManager.cs
@@ -26,7 +26,6 @@ public class TextureManager : SingletonBehaviour<TextureManager>
 
     private void Start()
     {
-
         mainMenuImageBackgroundMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
         mainMenuBackgroundMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
         mainMenuTextImageMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Transparent);
@@ -34,15 +33,6 @@ public class TextureManager : SingletonBehaviour<TextureManager>
         gothicLoadingMenuMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
         loadingBarBackgroundMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
         loadingBarMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
-
-        // These elements get their material assigned in Editor already.
-        // TODO: remove the middleman materials and use these for settings menu
-        // backgroundmaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
-        // buttonmaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Transparent);
-        // slidermaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Transparent);
-        // sliderpositionmaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Transparent);
-        // arrowmaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Transparent);
-        // fillermaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Transparent);
 
         loadingSphereMaterial = GetEmptyMaterial(MaterialExtension.BlendMode.Opaque);
         loadingSphereMaterial.color = new Color(.25f, .25f, .25f, 1f); // dark gray


### PR DESCRIPTION
…y will be set at game startup without saving to .mat file directly.

Two major changes:
1. I removed the OnValidate() function which calls ```SetShaderProperties()``` as this alters values inside GothicSky.mat before the game starts but should only reflect runtime changes. The ```SetShaderProperties()``` is also called during game startup which is:
```WorldCreator.CreateAsync() -> InitSky() -> Interpolate() -> InterpolateSky() -> SetShaderProperties()``` after world is loaded and before loading screne is gone.
2. GothicSky was set directly on world.unity scene. Therefore we couldn't overwrite it. Now setting the value at runtime when world is fully loaded dynamically as a clone.

Tests showed the sky is fine at startup.