### PR TITLE
fix(AbstractMeshBuilder): Added textures to vob elements which are dy…

### DIFF
--- a/Assets/GothicVR/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
+++ b/Assets/GothicVR/Scripts/Creator/Meshes/V2/Builder/AbstractMeshBuilder.cs
@@ -252,6 +252,12 @@ namespace GVR.Creator.Meshes.V2.Builder
                 meshRenderer.material = Constants.LoadingMaterial;
 
                 PrepareMeshFilter(meshFilter, subMesh.Value, meshRenderer);
+
+                if (!UseTextureArray)
+                {
+                    PrepareMeshRenderer(meshRenderer, subMesh.Value);
+                }
+                
                 PrepareMeshCollider(meshObj, meshFilter.sharedMesh, subMesh.Value.Materials);
             }
 


### PR DESCRIPTION
…namically loaded inside lab.

# To test
1. Start lab and look at ladder and chest+door - Do they have textures?
2. Start main game briefly and look if objects (items like berry) and static vobs (like ladder) also still have their textures.

Out-of-Scope:
* I didn't fix it for the item tool where you spawn items as this would cause merge conflicts when we merge HVR branch. Let's update this later. It's 1 line only: _CreateVob(..., useTextureArray: false)_