### PR TITLE
fix(NpcHelper): Lowered lookup distance. (Otherwise PEE fps will be s…

### DIFF
--- a/Assets/GothicVR/Scripts/Manager/NpcHelper.cs
+++ b/Assets/GothicVR/Scripts/Manager/NpcHelper.cs
@@ -19,7 +19,7 @@ namespace GVR.Manager
 {
     public static class NpcHelper
     {
-        private const float fpLookupDistance = 20f; // meter
+        private const float fpLookupDistance = 7f; // meter
 
         static NpcHelper()
         {


### PR DESCRIPTION
…eeked within nearly whole OC.)

# To test
1. Spawn Grim (580) a few times and look if he walks into the music stage - if he just stands around the fire, we're fine. (Lowered lookup distance for PEE search. Before the fix, he walked into the inner circle's walls to pee)
2. ...
3. ...


# Checklist
(Please remove entries which aren't needed for your PR)

## Scene
* [ ] FeatureFlags reverted to right value

# Testing
* [ ] Merged _main_ into this branch and tested with the latest features
* [ ] Tested with PCVR
* [ ] Tested with Pico / Quest
